### PR TITLE
added getLast30DayAverages API and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# build output
+build/

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/SleepLogRepository.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/SleepLogRepository.java
@@ -1,13 +1,18 @@
 package com.noom.interview.fullstack.sleep.sleeplog;
 
 import com.noom.interview.fullstack.sleep.sleeplog.models.SleepLog;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SleepLogRepository extends CrudRepository<SleepLog, Long> {
     Optional<SleepLog> findFirstByUserIdOrderBySleepDateDesc(Long userId);
 
+    @Query(value = "SELECT * FROM sleep_log WHERE user_id = :userId ORDER BY sleep_date DESC LIMIT 30", nativeQuery = true)
+    List<SleepLog> findLast30ByUserId(@Param("userId") Long userId);
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/SleepLogService.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/SleepLogService.java
@@ -1,6 +1,7 @@
 package com.noom.interview.fullstack.sleep.sleeplog;
 
 import com.noom.interview.fullstack.sleep.sleeplog.Utils.ConversionUtil;
+import com.noom.interview.fullstack.sleep.sleeplog.dto.SleepLogAveragesDTO;
 import com.noom.interview.fullstack.sleep.sleeplog.dto.SleepLogDTO;
 import com.noom.interview.fullstack.sleep.sleeplog.models.SleepLog;
 import com.noom.interview.fullstack.sleep.user.UserRepository;
@@ -34,5 +35,9 @@ public class SleepLogService {
                 .map(ConversionUtil::convertToSleepLogDTO)
                 .orElse(null);
 
+    }
+
+    public SleepLogAveragesDTO getLast30DayAverages(long userId) {
+        return SleepLogAveragesDTO.fromLogs(sleepLogRepository.findLast30ByUserId(userId));
     }
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/Utils/ConversionUtil.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/Utils/ConversionUtil.java
@@ -26,7 +26,9 @@ public class ConversionUtil {
             return null;
         }
         SleepLog sleepLog = new SleepLog();
-        sleepLog.setId(sleepLogDTO.getId());
+        if(sleepLogDTO.getSleepDate() != null)
+            sleepLog.setSleepDate(sleepLogDTO.getSleepDate());
+
         sleepLog.setTimeInBedInterval(convertToTimeInBedInterval(sleepLogDTO.getTimeInBedInterval()));
         sleepLog.setTotalTimeInBedSeconds(sleepLogDTO.getTotalTimeInBedSeconds());
         sleepLog.setMorningFeeling(sleepLogDTO.getMorningFeeling());

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/controller/SleepLogController.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/controller/SleepLogController.java
@@ -1,6 +1,7 @@
 package com.noom.interview.fullstack.sleep.sleeplog.controller;
 
 import com.noom.interview.fullstack.sleep.sleeplog.SleepLogService;
+import com.noom.interview.fullstack.sleep.sleeplog.dto.SleepLogAveragesDTO;
 import com.noom.interview.fullstack.sleep.sleeplog.dto.SleepLogDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -32,5 +33,15 @@ public class SleepLogController {
             return ResponseEntity.ok(sleepLogDTO);
         }
         return ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/averages_last_30_days")
+    public ResponseEntity<SleepLogAveragesDTO> getLast30DayAverages() {
+        SleepLogAveragesDTO averagesDTO = sleepLogService.getLast30DayAverages(userId);
+        if (averagesDTO != null) {
+            return ResponseEntity.ok(averagesDTO);
+        }
+        return ResponseEntity.notFound().build();
+
     }
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/dto/SleepLogAveragesDTO.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/dto/SleepLogAveragesDTO.java
@@ -1,0 +1,59 @@
+package com.noom.interview.fullstack.sleep.sleeplog.dto;
+
+import com.noom.interview.fullstack.sleep.sleeplog.models.MorningFeeling;
+import com.noom.interview.fullstack.sleep.sleeplog.models.SleepLog;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class SleepLogAveragesDTO {
+    LocalDate startDate;
+    LocalDate endDate;
+    double averageTotalTimeInBedSeconds;
+    double averageGoToBedTime;  // in seconds from midnight
+    double averageWakeUpTime;   // in seconds from midnight
+    Map<MorningFeeling, Double> feelingCounts;
+
+    public static SleepLogAveragesDTO fromLogs(List<SleepLog> sleepLogs) {
+        if (sleepLogs == null || sleepLogs.isEmpty()) {
+            return null;
+        }
+        SleepLogAveragesDTO averages = new SleepLogAveragesDTO();
+
+        sleepLogs.sort(Comparator.comparing(SleepLog::getSleepDate));
+        averages.startDate = sleepLogs.get(0).getSleepDate().toLocalDate();
+        averages.endDate = sleepLogs.get(sleepLogs.size() - 1).getSleepDate().toLocalDate();
+
+        double totalTimeInBedSum = 0;
+        double totalGoToBedSeconds = 0;
+        double totalWakeUpSeconds = 0;
+
+        Map<MorningFeeling, Double> feelingCounts = new EnumMap<>(MorningFeeling.class);
+        for (MorningFeeling feeling : MorningFeeling.values()) {
+            feelingCounts.put(feeling, 0.0);
+        }
+
+        for (SleepLog log : sleepLogs) {
+            totalTimeInBedSum += log.getTotalTimeInBedSeconds();
+            totalGoToBedSeconds += log.getTimeInBedInterval().getStartTime().toLocalTime().toSecondOfDay();
+            totalWakeUpSeconds += log.getTimeInBedInterval().getEndTime().toLocalTime().toSecondOfDay();
+
+
+            MorningFeeling feeling = log.getMorningFeeling();
+            feelingCounts.put(feeling, feelingCounts.get(feeling) + 1.0);
+        }
+
+        int totalLogs = sleepLogs.size();
+        averages.averageTotalTimeInBedSeconds = totalTimeInBedSum / totalLogs;
+        averages.averageGoToBedTime = totalGoToBedSeconds / totalLogs;
+        averages.averageWakeUpTime = totalWakeUpSeconds / totalLogs;
+        averages.feelingCounts = new EnumMap<>(feelingCounts);
+        return averages;
+    }
+
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/models/TimeInBedInterval.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/sleeplog/models/TimeInBedInterval.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -18,7 +19,8 @@ public class TimeInBedInterval {
     @GeneratedValue
     private long id;
 
+    @Column(nullable = false)
     private LocalDateTime startTime;
-
+    @Column(nullable = false)
     private LocalDateTime endTime;
 }

--- a/sleep/src/main/resources/db/migration/V2.1__make_start_end_time_not_null.sql
+++ b/sleep/src/main/resources/db/migration/V2.1__make_start_end_time_not_null.sql
@@ -1,0 +1,3 @@
+ALTER TABLE time_in_bed_interval
+    ALTER COLUMN start_time SET NOT NULL,
+    ALTER COLUMN end_time SET NOT NULL;

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/SleepLogControllerTest.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/SleepLogControllerTest.java
@@ -81,4 +81,13 @@ class SleepLogControllerTest {
         mockMvc.perform(get("/sleeplog/fetch_last_night"))
                 .andExpect(status().isNotFound());
     }
+
+    @Test
+    void shouldReturnNotFoundWhenNoSleepLogsForLast30Days() throws Exception {
+        Mockito.when(sleepLogService.getLast30DayAverages(1L)).thenReturn(null);
+
+        mockMvc.perform(get("/sleeplog/averages_last_30_days"))
+                .andExpect(status().isNotFound());
+    }
+
 }

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/SleepLogLogicTest.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/SleepLogLogicTest.java
@@ -1,0 +1,111 @@
+package com.noom.interview.fullstack.sleep;
+
+import com.noom.interview.fullstack.sleep.sleeplog.Utils.ConversionUtil;
+import com.noom.interview.fullstack.sleep.sleeplog.dto.SleepLogAveragesDTO;
+import com.noom.interview.fullstack.sleep.sleeplog.dto.SleepLogDTO;
+import com.noom.interview.fullstack.sleep.sleeplog.dto.TimeInBedIntervalDTO;
+import com.noom.interview.fullstack.sleep.sleeplog.models.MorningFeeling;
+import com.noom.interview.fullstack.sleep.sleeplog.models.SleepLog;
+import com.noom.interview.fullstack.sleep.sleeplog.models.TimeInBedInterval;
+import com.noom.interview.fullstack.sleep.user.models.User;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+
+class SleepLogLogicTest {
+
+    @Test
+    void sleepLogToDTOConversionTest() {
+        SleepLog sleepLog = new SleepLog();
+        TimeInBedInterval timeInBedInterval = new TimeInBedInterval();
+        User user = new User(1L, "TestUser", null);
+        timeInBedInterval.setStartTime(LocalDateTime.of(2025, 10, 1, 22, 0));
+        timeInBedInterval.setEndTime(LocalDateTime.of(2025, 10, 2, 22, 0));
+        sleepLog.setId(1L);
+        sleepLog.setTotalTimeInBedSeconds(20000);
+        sleepLog.setMorningFeeling(MorningFeeling.BAD);
+        sleepLog.setTimeInBedInterval(timeInBedInterval);
+        sleepLog.setUser(user);
+
+        SleepLogDTO sleepLogDTO = ConversionUtil.convertToSleepLogDTO(sleepLog);
+
+        assert sleepLogDTO != null;
+        assert sleepLogDTO.getTotalTimeInBedSeconds() == 20000;
+        assert sleepLogDTO.getMorningFeeling() == MorningFeeling.BAD;
+        assert sleepLogDTO.getTimeInBedInterval() != null;
+        assert sleepLogDTO.getTimeInBedInterval().getStartTime().equals(LocalDateTime.of(2025, 10, 1, 22, 0));
+        assert sleepLogDTO.getTimeInBedInterval().getEndTime().equals(LocalDateTime.of(2025, 10, 2, 22, 0));
+        assert sleepLogDTO.getSleepDate().equals(sleepLog.getSleepDate());
+
+    }
+
+    @Test
+    void sleepLogDTOToSleepLogConversionTest() {
+        SleepLogDTO sleepLogDTO = new SleepLogDTO();
+        sleepLogDTO.setId(1L);
+        sleepLogDTO.setTotalTimeInBedSeconds(20000);
+        sleepLogDTO.setMorningFeeling(MorningFeeling.BAD);
+        TimeInBedIntervalDTO timeInBedInterval = new TimeInBedIntervalDTO();
+        timeInBedInterval.setStartTime(LocalDateTime.of(2025, 10, 1, 22, 0));
+        timeInBedInterval.setEndTime(LocalDateTime.of(2025, 10, 2, 22, 0));
+        sleepLogDTO.setTimeInBedInterval(timeInBedInterval);
+
+        SleepLog sleepLog = ConversionUtil.convertToSleepLog(sleepLogDTO);
+
+        assert sleepLog != null;
+        assert sleepLog.getTotalTimeInBedSeconds() == 20000;
+        assert sleepLog.getMorningFeeling() == MorningFeeling.BAD;
+        assert sleepLog.getTimeInBedInterval() != null;
+        assert sleepLog.getTimeInBedInterval().getStartTime().equals(LocalDateTime.of(2025, 10, 1, 22, 0));
+        assert sleepLog.getTimeInBedInterval().getEndTime().equals(LocalDateTime.of(2025, 10, 2, 22, 0));
+    }
+
+    @Test
+    void testSleepLogAveragesCalculation() {
+        User user = new User(1L, "TestUser", null);
+
+        TimeInBedInterval interval1 = new TimeInBedInterval(0,
+                LocalDateTime.of(2025, 10, 1, 22, 0),
+                LocalDateTime.of(2025, 10, 2, 6, 0)
+                );
+
+        TimeInBedInterval interval2 = new TimeInBedInterval(1,
+                LocalDateTime.of(2025, 10, 2, 22, 0),
+                LocalDateTime.of(2025, 10, 3, 6, 20)
+                );
+
+        TimeInBedInterval interval3 = new TimeInBedInterval(2,
+                LocalDateTime.of(2025, 10, 3, 22, 0),
+                LocalDateTime.of(2025, 10, 4, 5, 30));
+
+        List<SleepLog> sleepLogs = new ArrayList<>(List.of(
+                new SleepLog(1L, LocalDateTime.of(2025, 10, 1, 22, 0), interval1, 28800, MorningFeeling.GOOD, user),
+                new SleepLog(2L, LocalDateTime.of(2025, 10, 2, 22, 0), interval2, 30000, MorningFeeling.OK, user),
+                new SleepLog(3L, LocalDateTime.of(2025, 10, 3, 22, 0), interval3, 27000, MorningFeeling.BAD, user)
+        ));
+
+        SleepLogAveragesDTO averages = SleepLogAveragesDTO.fromLogs(sleepLogs);
+        
+        assert averages != null;
+        assert averages.getStartDate().equals(LocalDateTime.of(2025, 10, 1, 22, 0).toLocalDate());
+        assert averages.getEndDate().equals(LocalDateTime.of(2025, 10, 3, 22, 0).toLocalDate());
+        assert averages.getAverageTotalTimeInBedSeconds() == (28800 + 30000 + 27000) / 3.0;
+        assert averages.getAverageGoToBedTime() == 
+                (interval1.getStartTime().toLocalTime().toSecondOfDay() + 
+                 interval2.getStartTime().toLocalTime().toSecondOfDay() + 
+                 interval3.getStartTime().toLocalTime().toSecondOfDay()) / 3.0;
+        assert averages.getAverageWakeUpTime() ==
+                (interval1.getEndTime().toLocalTime().toSecondOfDay() + 
+                 interval2.getEndTime().toLocalTime().toSecondOfDay() + 
+                 interval3.getEndTime().toLocalTime().toSecondOfDay()) / 3.0;
+        assert averages.getFeelingCounts().get(MorningFeeling.GOOD) == 1.0;
+        assert averages.getFeelingCounts().get(MorningFeeling.OK) == 1.0;
+        assert averages.getFeelingCounts().get(MorningFeeling.BAD) == 1.0;
+        
+        
+    }
+
+}


### PR DESCRIPTION
## Description of changes 🪄

This merge request introduces a new API endpoint to compute sleep log averages for the last 30 days:

### Endpoint
`GET /sleeplog/averages_last_30_days`

### Response example:
```json
{
  "startDate": "2025-05-22",
  "endDate": "2025-05-28",
  "averageTotalTimeInBedSeconds": 24953.846153846152,
  "averageGoToBedTime": 81000.0,
  "averageWakeUpTime": 23400.0,
  "feelingCounts": {
    "GOOD": 2.0,
    "OK": 1.0,
    "BAD": 10.0
  }
}
``` 

---

## New Code Checklists 💾

- [ ] Fix bug  
- [x] New feature  
- [ ] Breaking changes  
- [x] Unit test added  

---

## Merge Request Checklists 💯

- [x] Code is formatted and reviewed  
- [x] Unit tests are added and passing 